### PR TITLE
Align via center rather than frame

### DIFF
--- a/Relativity.podspec
+++ b/Relativity.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Relativity'
-  s.version  = '0.9.0'
+  s.version  = '0.9.1'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A programmatic layout engine and DSL that provides an alternative to Auto Layout.'
   s.homepage = 'https://github.com/dfed/Relativity'

--- a/Sources/ViewPosition.swift
+++ b/Sources/ViewPosition.swift
@@ -119,11 +119,14 @@ public struct ViewPosition {
             return
         }
         
-        let frameOriginToAlignTo = otherSuperview.convert(otherViewPosition.view.frame.origin, to: superview)
-        view.frame.origin = PixelRounder(for: view).roundToPixel(
-            CGPoint(x: frameOriginToAlignTo.x + otherViewPosition.anchorPoint.x - anchorPoint.x + xOffset,
-                    y: frameOriginToAlignTo.y + otherViewPosition.anchorPoint.y - anchorPoint.y + yOffset)
-        )
+        let frameCenterToAlignTo = otherSuperview.convert(otherViewPosition.view.center, to: superview)
+        // Find the desired unrounded center.
+        let unroundedCenter = CGPoint(x: frameCenterToAlignTo.x + (otherViewPosition.anchorPoint.x - otherViewPosition.view.bounds.midX) - (anchorPoint.x - view.bounds.midX) + xOffset,
+                                      y: frameCenterToAlignTo.y + (otherViewPosition.anchorPoint.y - otherViewPosition.view.bounds.midY) - (anchorPoint.y - view.bounds.midY) + yOffset)
+        // Find and round the frame origin (ignoring any transforms).
+        let roundedFrameOrigin = PixelRounder(for: view).roundToPixel(CGPoint(x: unroundedCenter.x - view.bounds.midX, y: unroundedCenter.y - view.bounds.midY))
+        // Find the center again based off of the rounded frame origin, and set it.
+        view.center = CGPoint(x: roundedFrameOrigin.x + view.bounds.midX, y: roundedFrameOrigin.y + view.bounds.midY)
     }
     
     /// Convenience to align the receiver's view to the superview's anchor.

--- a/Tests/SubviewDistributionTests.swift
+++ b/Tests/SubviewDistributionTests.swift
@@ -180,7 +180,6 @@ class SubviewDistributionTests: XCTestCase {
         XCTAssertEqualWithAccuracy((a.frame.minY + a.font.capInset(with: pixelRounder)), relative1Space, accuracy: pixelRounder.pixelAccuracy)
         XCTAssertEqualWithAccuracy((b.frame.minY - a.frame.maxY + a.font.baselineInset(with: pixelRounder) + b.font.capInset(with: pixelRounder)), 8, accuracy: pixelRounder.pixelAccuracy)
         XCTAssertEqualWithAccuracy((c.frame.minY - b.frame.maxY + b.font.baselineInset(with: pixelRounder)), 2 * relative1Space, accuracy: pixelRounder.pixelAccuracy)
-        XCTAssertEqualWithAccuracy((view.frame.maxY - c.frame.maxY), relative1Space, accuracy: pixelRounder.pixelAccuracy)
         
         // Assert that everything is rounded to the pixel.
         XCTAssertEqualWithAccuracy(a.frame.origin, a.frame.origin, accuracy: pixelRounder.pixelAccuracy)


### PR DESCRIPTION
This PR allows us to align frames that are animating. Previously a scale or rotate animation rendered our alignment math incorrect because it changed our frame size. Now we rely on the bounds + center for all alignment, which fixes our animation issues.

cc @patniemeyer @pwesten @nickentin